### PR TITLE
Add the pipeline that allows to push Arcane to public.ecr.aws repository

### DIFF
--- a/.github/workflows/publish-ecr-public.yaml
+++ b/.github/workflows/publish-ecr-public.yaml
@@ -1,0 +1,92 @@
+name: Publish Arcane.Stream.RestApi to ECR public registry
+run-name: Publish Arcane.Stream.SqlServerChangeTracking to public.ecr.aws by @${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: |
+          Version number to publish. Defaults to the latest git tag in the repository. 
+          This version MUST exist in the ghcr.io registry.
+        required: false
+        default: "current"
+
+env:
+  PROJECT_NAME: Arcane.Stream.SqlServerChangeTracking
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  publish_image:
+    name: Publish Docker Image to ECR Public
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/tags') }}
+
+    permissions:
+      contents: read
+      id-token: write
+    
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+
+      - name: Get project version
+        uses: SneaksAndData/github-actions/generate_version@v0.1.9
+        id: current_version
+
+      - name: Set up variables
+        env:
+          VERSION: ${{ inputs.version }}
+          CURRENT_VERSION: ${{steps.current_version.outputs.version}}
+        run: |
+          test "$VERSION" == "current" && echo "IMAGE_VERSION=$CURRENT_VERSION" >> ${GITHUB_ENV} || echo "IMAGE_VERSION=$VERSION" >> ${GITHUB_ENV} 
+
+      - name: Import AWS Secrets
+        uses: hashicorp/vault-action@v3.0.0
+        with:
+          url: https://hashicorp-vault.awsp.sneaksanddata.com/
+          role: github
+          method: jwt
+          secrets: |
+            /secret/data/common/package-publishing/aws-ecr-public/production/container-user-public access_key | ACCESS_KEY ;
+            /secret/data/common/package-publishing/aws-ecr-public/production/container-user-public access_key_id | ACCESS_KEY_ID ;
+        id: aws_secrets
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4.0.2
+        with:
+          aws-access-key-id: ${{ env.ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ env.ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Log in to the GitHub Container Registry
+        uses: docker/login-action@v3.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Amazon ECR Public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ env.IMAGE_VERSION }}
+          flavor:
+            latest=false
+
+      - name: Push image to ECR Public registry
+        uses: akhilerm/tag-push-action@v2.2.0
+        with:
+          src: ${{ steps.meta.outputs.tags }}
+          dst: public.ecr.aws/ecco-sneaks-and-data/arcane/${{ github.event.repository.name }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
Add the pipeline that is used for publishing the docker image to public.ecr.aws

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.