### PR TITLE
Implements support for the stream metadata

### DIFF
--- a/.helm/templates/crd-sql-server-change-tracking.yaml
+++ b/.helm/templates/crd-sql-server-change-tracking.yaml
@@ -109,6 +109,22 @@ spec:
                   description: How long to wait before polling for next result set. Can be from 1 to 60 seconds.
                   minimum: 1
                   maximum: 60
+                streamMetadata:
+                  type: object
+                  optional: true
+                  default: null
+                  properties:
+                    partitions:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          fieldName:
+                            type: string
+                          fieldFormat:
+                            type: string
             status:
               type: object
               properties:

--- a/src/Arcane.Stream.SqlServerChangeTracking.csproj
+++ b/src/Arcane.Stream.SqlServerChangeTracking.csproj
@@ -5,7 +5,7 @@
         <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Arcane.Framework" Version="0.0.36" />
+        <PackageReference Include="Arcane.Framework" Version="0.0.37" />
     </ItemGroup>
 
 </Project>

--- a/src/Arcane.Stream.SqlServerChangeTracking.csproj
+++ b/src/Arcane.Stream.SqlServerChangeTracking.csproj
@@ -5,7 +5,7 @@
         <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Arcane.Framework" Version="0.0.38" />
+        <PackageReference Include="Arcane.Framework" Version="0.0.37" />
     </ItemGroup>
 
 </Project>

--- a/src/Arcane.Stream.SqlServerChangeTracking.csproj
+++ b/src/Arcane.Stream.SqlServerChangeTracking.csproj
@@ -5,7 +5,7 @@
         <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Arcane.Framework" Version="0.0.35" />
+        <PackageReference Include="Arcane.Framework" Version="0.0.36" />
     </ItemGroup>
 
 </Project>

--- a/src/Arcane.Stream.SqlServerChangeTracking.csproj
+++ b/src/Arcane.Stream.SqlServerChangeTracking.csproj
@@ -5,7 +5,7 @@
         <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Arcane.Framework" Version="0.0.37" />
+        <PackageReference Include="Arcane.Framework" Version="0.0.38" />
     </ItemGroup>
 
 </Project>

--- a/src/Models/SqlServerChangeTrackingStreamContext.cs
+++ b/src/Models/SqlServerChangeTrackingStreamContext.cs
@@ -5,7 +5,6 @@ using Akka.Util;
 using Arcane.Framework.Configuration;
 using Arcane.Framework.Services.Base;
 using Arcane.Framework.Services.Models;
-using Arcane.Framework.Sinks.Extensions;
 using Arcane.Framework.Sinks.Models;
 
 namespace Arcane.Stream.SqlServerChangeTracking.Models;
@@ -48,7 +47,7 @@ public class SqlServerChangeTrackingStreamContext : IStreamContext, IStreamConte
     /// Data location for parquet files.
     /// </summary>
     public string SinkLocation { get; set; }
-
+    
     /// <summary>
     /// Number of seconds to look back when determining first set of changes to extract.
     /// </summary>
@@ -77,20 +76,30 @@ public class SqlServerChangeTrackingStreamContext : IStreamContext, IStreamConte
     /// <summary>
     /// Property to hold stream metadata received from the stream context.
     /// </summary>
-    public StreamMetadataDefinition StreamMetadata { get; set; }
+    [JsonPropertyName("streamMetadata")]
+    public StreamMetadataDefinition StreamMetadataProperty { get; set; }
 
-    public Option<StreamMetadata> GetStreamMetadata()
+    /// <inheritdoc cref="IStreamContext.StreamMetadata"/>
+    [JsonIgnore]
+    public Option<StreamMetadata> StreamMetadata
     {
-        if (this.StreamMetadata is null)
+        get
         {
-            return Option<StreamMetadata>.None;
-        }
+            if (this.StreamMetadataProperty is null)
+            {
+                return Option<StreamMetadata>.None;
+            }
 
-        var partitions = this.StreamMetadata
-            .Partitions
-            .Select(p => p.ToStreamPartition())
-            .ToArray();
-        return new StreamMetadata(partitions);
+            var partitions = this.StreamMetadataProperty
+                .Partitions
+                .Select(partition => new StreamPartition
+            {
+                Name = partition.Name,
+                FieldName = partition.FieldName,
+                FieldFormat = partition.FieldFormat
+            }).ToArray();
+            return new StreamMetadata(partitions);
+        }
     }
 
     /// <inheritdoc cref="IStreamContextWriter.SetStreamId"/>
@@ -110,12 +119,12 @@ public class SqlServerChangeTrackingStreamContext : IStreamContext, IStreamConte
     {
         this.StreamKind = streamKind;
     }
-
+    
     public void LoadSecretsFromEnvironment()
     {
         this.ConnectionString = this.GetSecretFromEnvironment("CONNECTIONSTRING");
     }
-
+    
     private string GetSecretFromEnvironment(string secretName)
         => Environment.GetEnvironmentVariable($"{nameof(Arcane)}__{secretName}".ToUpperInvariant());
 }

--- a/src/Models/SqlServerChangeTrackingStreamContext.cs
+++ b/src/Models/SqlServerChangeTrackingStreamContext.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Text.Json.Serialization;
+using Akka.Util;
+using Akka.Util.Extensions;
 using Arcane.Framework.Configuration;
 using Arcane.Framework.Services.Base;
+using Arcane.Framework.Sinks.Models;
 
 namespace Arcane.Stream.SqlServerChangeTracking.Models;
 
@@ -68,6 +71,16 @@ public class SqlServerChangeTrackingStreamContext : IStreamContext, IStreamConte
 
     /// <inheritdoc cref="IStreamContext.StreamKind"/>
     public string StreamKind { get; private set; }
+
+    /// <summary>
+    /// Property to hold stream metadata received from the stream context.
+    /// </summary>
+    [JsonPropertyName("streamMetadata")]
+    public StreamMetadata StreamMetadataProperty { get; set; }
+
+    /// <inheritdoc cref="IStreamContext.StreamMetadata"/>
+    [JsonIgnore]
+    public Option<StreamMetadata> StreamMetadata => this.StreamMetadataProperty.AsOption();
 
     /// <inheritdoc cref="IStreamContextWriter.SetStreamId"/>
     public void SetStreamId(string streamId)

--- a/src/Services/SqlServerChangeTrackgingGraphBuilder.cs
+++ b/src/Services/SqlServerChangeTrackgingGraphBuilder.cs
@@ -4,8 +4,10 @@ using System.Linq;
 using System.Threading.Tasks;
 using Akka.Streams;
 using Akka.Streams.Dsl;
+using Akka.Util;
 using Arcane.Framework.Contracts;
 using Arcane.Framework.Services.Base;
+using Arcane.Framework.Sinks.Models;
 using Arcane.Framework.Sinks.Parquet;
 using Arcane.Framework.Sources.Exceptions;
 using Arcane.Framework.Sources.SqlServer;
@@ -51,7 +53,8 @@ public class SqlServerChangeTrackingGraphBuilder(
                 rowGroupsPerFile: context.GroupsPerFile,
                 createSchemaFile: true,
                 dataSinkPathSegment: context.IsBackfilling ? "backfill" : "data",
-                dropCompletionToken: context.IsBackfilling);
+                dropCompletionToken: context.IsBackfilling,
+                streamMetadata: context.StreamMetadata.GetOrElse(new StreamMetadata(Option<StreamPartition[]>.None)));
 
             return Source
                 .FromGraph(source)


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/arcane-framework/issues/113


## Scope

Implemented:
- Added support for custom stream metadata implemented in arcane framework.

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.