### PR TITLE
Set up infrastructure for MSSQL unit tests

### DIFF
--- a/.github/workflows/build-scala.yaml
+++ b/.github/workflows/build-scala.yaml
@@ -30,6 +30,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Scala
         uses: japgolly/setup-everything-scala@v3.1
+      - name: Build the Docker Compose stack
+        run: docker compose up -d
       - name: Build and test
         shell: bash
         run: sbt++field scala361 test

--- a/.github/workflows/build-scala.yaml
+++ b/.github/workflows/build-scala.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Scala
         uses: japgolly/setup-everything-scala@v3.1
         with:
-          java-version: openjdk:23
+          java-version: temurin:1.23.0.1
       - name: Build the Docker Compose stack
         run: docker compose up -d
       - name: Build and test

--- a/.github/workflows/build-scala.yaml
+++ b/.github/workflows/build-scala.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Scala
         uses: japgolly/setup-everything-scala@v3.1
         with:
-          java-version: openjdk:14
+          java-version: adopt:11.0.6
       - name: Build the Docker Compose stack
         run: docker compose up -d
       - name: Build and test

--- a/.github/workflows/build-scala.yaml
+++ b/.github/workflows/build-scala.yaml
@@ -30,6 +30,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Scala
         uses: japgolly/setup-everything-scala@v3.1
+        with:
+          java-version: openjdk:14
       - name: Build the Docker Compose stack
         run: docker compose up -d
       - name: Build and test

--- a/.github/workflows/build-scala.yaml
+++ b/.github/workflows/build-scala.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Scala
         uses: japgolly/setup-everything-scala@v3.1
         with:
-          java-version: adopt:11.0.6
+          java-version: openjdk:23
       - name: Build the Docker Compose stack
         run: docker compose up -d
       - name: Build and test

--- a/framework/arcane-framework/docker-compose.yaml
+++ b/framework/arcane-framework/docker-compose.yaml
@@ -1,0 +1,12 @@
+version: '3.3'
+
+services:
+  mssql:
+    container_name: sql-server
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    restart: always
+    environment:
+      ACCEPT_EULA: "Y"
+      SA_PASSWORD: "tMIxN11yGZgMC"
+    ports:
+      - "1433:1433"

--- a/framework/arcane-framework/src/test/scala/services/connectors/mssql/MsSqlConnectorsTests.scala
+++ b/framework/arcane-framework/src/test/scala/services/connectors/mssql/MsSqlConnectorsTests.scala
@@ -1,0 +1,63 @@
+package com.sneaksanddata.arcane.framework
+package services.connectors.mssql
+
+import services.connectors.mssql.DbServer.{createDb, removeDb}
+
+import com.microsoft.sqlserver.jdbc.SQLServerDriver
+import org.scalatest.*
+import org.scalatest.flatspec.FixtureAnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.matchers.should.Matchers.*
+
+import java.sql.Connection
+import java.util.Properties
+import scala.language.postfixOps
+
+object DbServer:
+  private val connectionUrl = "jdbc:sqlserver://localhost;encrypt=true;trustServerCertificate=true;username=sa;password=tMIxN11yGZgMC"
+
+  def createDb(): Connection = {
+    val dr = new SQLServerDriver()
+    val con = dr.connect(connectionUrl, new Properties())
+    val query = "IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = 'arcane') BEGIN CREATE DATABASE arcane; alter database Arcane set CHANGE_TRACKING = ON (CHANGE_RETENTION = 2 DAYS, AUTO_CLEANUP = ON); END;"
+    val statement = con.createStatement()
+    statement.execute(query)
+    con
+  }
+
+  def removeDb(): Unit =
+    val query = "DROP DATABASE arcane"
+    val dr = new SQLServerDriver()
+    val con = dr.connect(connectionUrl, new Properties())
+    val statement = con.createStatement()
+    statement.execute(query)
+
+trait DbFixture:
+
+  this: FixtureTestSuite =>
+
+  type FixtureParam = Connection
+
+  // Allow clients to populate the database after
+  // it is created
+  def populateDb(db: Connection): Unit = {}
+
+  def withFixture(test: OneArgTest): Outcome =
+    val conn = createDb()
+    try {
+      populateDb(conn)
+      withFixture(test.toNoArgTest(conn)) // "loan" the fixture to the test
+    }
+    finally removeDb() // clean up the fixture
+
+
+
+class MsSqlConnectorsTests extends flatspec.FixtureAnyFlatSpec with Matchers with DbFixture:
+
+  override def populateDb(db: Connection): Unit =
+    println("ScalaTest is ")
+
+  "Testing" should "be easy" in { db =>
+    println("easy!")
+    assert(true)
+  }


### PR DESCRIPTION
Part of #61

## Scope

Implemented:
- Added docker-compose.yaml
- Added fixture for MS SQL Server tests.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.