### PR TITLE
Implement SQL server type parsing

### DIFF
--- a/framework/arcane-framework/src/main/scala/models/ArcaneSchema.scala
+++ b/framework/arcane-framework/src/main/scala/models/ArcaneSchema.scala
@@ -1,0 +1,42 @@
+package com.sneaksanddata.arcane.framework
+package models
+
+/**
+ * ArcaneSchema is a type alias for a sequence of fields or structs.
+ */
+type ArcaneSchema = Seq[Field|Struct]
+
+object ArcaneSchema:
+  def empty(): ArcaneSchema = Seq.empty
+
+
+/**
+ * Struct is a case class that represents a struct in Arcane.
+ * @param fields The fields of the struct.
+ */
+case class Struct(fields: ArcaneSchema)
+
+/**
+ * Types of fields in ArcaneSchema.
+ */
+enum ArcaneType:
+  case LongType
+  case ByteArrayType
+  case BooleanType
+  case StringType
+  case DateType
+  case TimestampType
+  case DateTimeOffsetType
+  case BigDecimalType
+  case DoubleType
+  case IntType
+  case FloatType
+  case ShortType
+  case TimeType
+  
+/**
+ * Field is a case class that represents a field in ArcaneSchema
+ * @param name The name of the field.
+ * @param fieldType The type of the field.
+ */
+case class Field(name: String, fieldType: ArcaneType)

--- a/framework/arcane-framework/src/main/scala/models/ArcaneSchema.scala
+++ b/framework/arcane-framework/src/main/scala/models/ArcaneSchema.scala
@@ -4,17 +4,11 @@ package models
 /**
  * ArcaneSchema is a type alias for a sequence of fields or structs.
  */
-type ArcaneSchema = Seq[Field|Struct]
+type ArcaneSchema = Seq[Field]
 
 object ArcaneSchema:
   def empty(): ArcaneSchema = Seq.empty
 
-
-/**
- * Struct is a case class that represents a struct in Arcane.
- * @param fields The fields of the struct.
- */
-case class Struct(fields: ArcaneSchema)
 
 /**
  * Types of fields in ArcaneSchema.

--- a/framework/arcane-framework/src/main/scala/models/ArcaneSchema.scala
+++ b/framework/arcane-framework/src/main/scala/models/ArcaneSchema.scala
@@ -6,7 +6,14 @@ package models
  */
 type ArcaneSchema = Seq[Field]
 
+/**
+ * Companion object for ArcaneSchema.
+ */
 object ArcaneSchema:
+  /**
+   * Creates an empty ArcaneSchema.
+   * @return An empty ArcaneSchema.
+   */
   def empty(): ArcaneSchema = Seq.empty
 
 

--- a/framework/arcane-framework/src/main/scala/services/base/SchemaProvider.scala
+++ b/framework/arcane-framework/src/main/scala/services/base/SchemaProvider.scala
@@ -1,19 +1,41 @@
 package com.sneaksanddata.arcane.framework
 package services.base
 
+import models.ArcaneType
+
 import scala.concurrent.Future
+
+/**
+ * Type class that represents the ability to add a field to a schema.
+ * @tparam Schema The type of the schema.
+ */
+trait CanAdd[Schema] :
+  /**
+   * Adds a field to the schema.
+   *
+   * @return The schema with the field added.
+   */
+  extension (a: Schema) def addField(fieldName: String, fieldType: ArcaneType): Schema
 
 /**
  * Represents a provider of a schema for a data produced by Arcane.
  *
  * @tparam Schema The type of the schema.
  */
-trait SchemaProvider[Schema] {
+trait SchemaProvider[Schema: CanAdd] {
 
+  type SchemaType = Schema
   /**
    * Gets the schema for the data produced by Arcane.
    *
    * @return A future containing the schema for the data produced by Arcane.
    */
-  def getSchema: Future[Schema]
+  def getSchema: Future[SchemaType]
+
+  /**
+   * Gets an empty schema.
+   *
+   * @return An empty schema.
+   */
+  def empty: SchemaType
 }

--- a/framework/arcane-framework/src/test/scala/services/connectors/mssql/MsSqlConnectorsTests.scala
+++ b/framework/arcane-framework/src/test/scala/services/connectors/mssql/MsSqlConnectorsTests.scala
@@ -85,7 +85,7 @@ class MsSqlConnectorsTests extends flatspec.AsyncFlatSpec with Matchers:
   "MsSqlConnection" should "be able to extract schema column names from the database" in withDatabase { dbInfo =>
     val connection = MsSqlConnection(dbInfo.connectionOptions)
     connection.getSchema map { schema =>
-      val fields = for column <- schema if column.isInstanceOf[Field] yield column.asInstanceOf[Field].name
+      val fields = for column <- schema if column.isInstanceOf[Field] yield column.name
       fields should be (List("x", "SYS_CHANGE_VERSION", "SYS_CHANGE_OPERATION", "y", "ChangeTrackingVersion", "ARCANE_MERGE_KEY", "DATE_PARTITION_KEY"))
     }
   }
@@ -94,7 +94,7 @@ class MsSqlConnectorsTests extends flatspec.AsyncFlatSpec with Matchers:
   "MsSqlConnection" should "be able to extract schema column types from the database" in withDatabase { dbInfo =>
     val connection = MsSqlConnection(dbInfo.connectionOptions)
     connection.getSchema map { schema =>
-      val fields = for column <- schema if column.isInstanceOf[Field] yield column.asInstanceOf[Field].fieldType
+      val fields = for column <- schema if column.isInstanceOf[Field] yield column.fieldType
       fields should be(List(IntType, LongType, StringType, IntType, LongType, StringType, StringType))
     }
   }


### PR DESCRIPTION
Part of #63 

## Scope:
- Implement intermediate abstraction ArcaneSchema for data schema translation
- Add ability to read columns schema with types to `MsSqlConnection`

Additional changes:
- Added type constant to the `SchemaProvider` trait
- The `Schema` parameter of the `SchemaProvider` trait was bound with the `CanAdd` typeclass

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.