### PR TITLE
Add backfill generation methods

### DIFF
--- a/framework/arcane-framework/src/main/resources/get_select_all_query.sql
+++ b/framework/arcane-framework/src/main/resources/get_select_all_query.sql
@@ -1,0 +1,7 @@
+﻿declare @currentVersion bigint = CHANGE_TRACKING_CURRENT_VERSION()
+
+SELECT
+{ChangeTrackingColumnsStatement},
+@currentVersion AS 'ChangeTrackingVersion',
+lower(convert(nvarchar(128), HashBytes('SHA2_256', {MERGE_EXPRESSION}),2)) as [{MERGE_KEY}]
+FROM [{dbName}].[{schema}].[{tableName}] tq

--- a/framework/arcane-framework/src/main/resources/get_select_all_query_date_partitioned.sql
+++ b/framework/arcane-framework/src/main/resources/get_select_all_query_date_partitioned.sql
@@ -1,0 +1,8 @@
+﻿declare @currentVersion bigint = CHANGE_TRACKING_CURRENT_VERSION()
+
+SELECT
+{ChangeTrackingColumnsStatement},
+@currentVersion AS 'ChangeTrackingVersion',
+lower(convert(nvarchar(128), HashBytes('SHA2_256', {MERGE_EXPRESSION}),2)) as [{MERGE_KEY}],
+{DATE_PARTITION_EXPRESSION} as [{DATE_PARTITION_KEY}]
+FROM [{dbName}].[{schema}].[{tableName}] tq

--- a/framework/arcane-framework/src/test/scala/services/connectors/mssql/MsSqlConnectorsTests.scala
+++ b/framework/arcane-framework/src/test/scala/services/connectors/mssql/MsSqlConnectorsTests.scala
@@ -82,6 +82,15 @@ class MsSqlConnectorsTests extends flatspec.AsyncFlatSpec with Matchers:
     }
   }
 
+  "QueryProvider" should "generate backfill query" in withDatabase { dbInfo =>
+    val connector = MsSqlConnection(dbInfo.connectionOptions)
+    QueryProvider.getBackfillQuery(connector) map { query =>
+      query should (
+        include ("ct.SYS_CHANGE_VERSION") and include ("ARCANE_MERGE_KEY") and include("format(getdate(), 'yyyyMM')")
+        )
+    }
+  }
+  
   "MsSqlConnection" should "be able to extract schema column names from the database" in withDatabase { dbInfo =>
     val connection = MsSqlConnection(dbInfo.connectionOptions)
     connection.getSchema map { schema =>


### PR DESCRIPTION
Part of #61

## Scope

This PR adds the method that generates backfill queries for the MS SQL source


## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.