### PR TITLE
Add the backfill implementation for MSSQL client

### DIFF
--- a/framework/arcane-framework/src/main/resources/get_select_all_query.sql
+++ b/framework/arcane-framework/src/main/resources/get_select_all_query.sql
@@ -1,4 +1,4 @@
-﻿declare @currentVersion bigint = CHANGE_TRACKING_CURRENT_VERSION()
+declare @currentVersion bigint = CHANGE_TRACKING_CURRENT_VERSION()
 
 SELECT
 {ChangeTrackingColumnsStatement},

--- a/framework/arcane-framework/src/main/resources/get_select_all_query_date_partitioned.sql
+++ b/framework/arcane-framework/src/main/resources/get_select_all_query_date_partitioned.sql
@@ -1,4 +1,4 @@
-﻿declare @currentVersion bigint = CHANGE_TRACKING_CURRENT_VERSION()
+declare @currentVersion bigint = CHANGE_TRACKING_CURRENT_VERSION()
 
 SELECT
 {ChangeTrackingColumnsStatement},

--- a/framework/arcane-framework/src/main/scala/models/DataCell.scala
+++ b/framework/arcane-framework/src/main/scala/models/DataCell.scala
@@ -13,10 +13,10 @@ type DataRow = List[DataCell]
  * @param Type The type of the row.
  * @param value The value of the row.
  */
-case class DataColumn(name: String, Type: ArcaneType, value: Any)
+case class DataCell(name: String, Type: ArcaneType, value: Any)
 
 /**
- * Companion object for [[DataColumn]].
+ * Companion object for [[DataCell]].
  */
-object DataColumn:
-  def apply(name: String, Type: ArcaneType, value: Any): DataColumn = new DataColumn(name, Type, value)
+object DataCell:
+  def apply(name: String, Type: ArcaneType, value: Any): DataCell = new DataCell(name, Type, value)

--- a/framework/arcane-framework/src/main/scala/models/DataColumn.scala
+++ b/framework/arcane-framework/src/main/scala/models/DataColumn.scala
@@ -4,7 +4,7 @@ package models
 /**
  * Represents a row of data.
  */
-type DataRow = List[DataColumn]
+type DataRow = List[DataCell]
 
 /**
  * Represents a row of data.

--- a/framework/arcane-framework/src/main/scala/models/DataColumn.scala
+++ b/framework/arcane-framework/src/main/scala/models/DataColumn.scala
@@ -1,0 +1,22 @@
+package com.sneaksanddata.arcane.framework
+package models
+
+/**
+ * Represents a row of data.
+ */
+type DataRow = List[DataColumn]
+
+/**
+ * Represents a row of data.
+ *
+ * @param name The name of the row.
+ * @param Type The type of the row.
+ * @param value The value of the row.
+ */
+case class DataColumn(name: String, Type: ArcaneType, value: Any)
+
+/**
+ * Companion object for [[DataColumn]].
+ */
+object DataColumn:
+  def apply(name: String, Type: ArcaneType, value: Any): DataColumn = new DataColumn(name, Type, value)

--- a/framework/arcane-framework/src/main/scala/services/mssql/QueryResult.scala
+++ b/framework/arcane-framework/src/main/scala/services/mssql/QueryResult.scala
@@ -1,0 +1,81 @@
+package com.sneaksanddata.arcane.framework
+package services.mssql
+
+import models.{DataColumn, DataRow}
+
+import java.sql.{ResultSet, Statement}
+import scala.annotation.tailrec
+
+/**
+ * Represents the result of a query to a SQL database.
+ */
+trait QueryResult[Output] {
+  
+  type OutputType = Output
+
+  /**
+   * Reads the result of the SQL query mapped to an output type.
+   *
+   * @return The result of the query.
+   */
+  def read: OutputType
+
+}
+
+/**
+ * Lazy-list based implementation of [[QueryResult]].
+ *
+ * @param statement The statement used to execute the query.
+ * @param resultSet The result set of the query.
+ */
+class LazyQueryResult(statement: Statement, resultSet: ResultSet) extends QueryResult[LazyList[DataRow]] with AutoCloseable {
+
+  /**
+   * Reads the result of the query.
+   *
+   * @return The result of the query.
+   */
+  override def read: this.OutputType =
+    val columns = resultSet.getMetaData.getColumnCount
+    LazyList.continually(resultSet)
+      .takeWhile(_.next())
+      .map(row => toDataRow(row, columns, List.empty))
+
+
+  /**
+   * Closes the statement and the result set owned by this object.
+   * When a Statement object is closed, its current ResultSet object, if one exists, is also closed.
+   */
+  override def close(): Unit = statement.close()
+
+  @tailrec
+  private def toDataRow(row: ResultSet, columns: Int, acc: DataRow): DataRow =
+    if columns == 0 then acc
+    else
+      val name = row.getMetaData.getColumnName(columns)
+      val value = row.getObject(columns)
+      val dataType = row.getMetaData.getColumnType(columns)
+      val arcaneType = MsSqlConnection.toArcaneType(dataType)
+      toDataRow(row, columns - 1, DataColumn(name, arcaneType, value) :: acc)
+
+}
+
+/**
+ * Companion object for [[LazyQueryResult]].
+ */
+object LazyQueryResult {
+  
+  /**
+   * The output type of the query result.
+   */
+  type OutputType = LazyList[DataRow]
+  
+  /**
+   * Creates a new [[LazyQueryResult]] object.
+   *
+   * @param statement The statement used to execute the query.
+   * @param resultSet The result set of the query.
+   * @return The new [[LazyQueryResult]] object.
+   */
+  def apply(statement: Statement, resultSet: ResultSet): LazyQueryResult = new LazyQueryResult(statement, resultSet)
+}

--- a/framework/arcane-framework/src/main/scala/services/mssql/QueryRunner.scala
+++ b/framework/arcane-framework/src/main/scala/services/mssql/QueryRunner.scala
@@ -1,0 +1,44 @@
+package com.sneaksanddata.arcane.framework
+package services.mssql
+
+import java.sql.{Connection, ResultSet, Statement}
+import scala.concurrent.{Future, blocking}
+
+/**
+ * A class that runs a query on a SQL database.
+ * This class is intended to run a single query and traverse the results only once using the forward-only read-only
+ * cursor.
+ *
+ */
+class QueryRunner:
+  
+  /**
+   * A factory for creating a QueryResult object from a statement and a result set.
+   *
+   * @tparam Output The type of the output of the query.
+   */
+  private type ResultFactory[Output] = (Statement, ResultSet) => QueryResult[Output]
+  
+  private implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+
+  /**
+   * Executes the given query on the given connection.
+   *
+   * The QueryResult object produced by this method must not outlive the connection object passed to it.
+   *
+   * @param query The query to execute.
+   * @param connection The connection to execute the query on.
+   * @return The result of the query.
+   */
+  def executeQuery[Result](query: MsSqlQuery, connection: Connection, resultFactory: ResultFactory[Result]): Future[QueryResult[Result]] =
+    Future {
+    val statement = connection.createStatement()
+    val resultSet = blocking {
+      statement.executeQuery(query)
+    }
+    resultFactory(statement, resultSet)
+  }
+
+
+object QueryRunner:
+  def apply(): QueryRunner = new QueryRunner()

--- a/framework/arcane-framework/src/test/scala/services/connectors/mssql/MsSqlConnectorsTests.scala
+++ b/framework/arcane-framework/src/test/scala/services/connectors/mssql/MsSqlConnectorsTests.scala
@@ -92,7 +92,7 @@ class MsSqlConnectorsTests extends flatspec.AsyncFlatSpec with Matchers:
     val connector = MsSqlConnection(dbInfo.connectionOptions)
     QueryProvider.getBackfillQuery(connector) map { query =>
       query should (
-        include ("ct.SYS_CHANGE_VERSION") and include ("ARCANE_MERGE_KEY") and include("format(getdate(), 'yyyyMM')")
+        include ("SYS_CHANGE_VERSION") and include ("ARCANE_MERGE_KEY") and include("format(getdate(), 'yyyyMM')")
         )
     }
   }

--- a/framework/arcane-framework/src/test/scala/services/connectors/mssql/MsSqlConnectorsTests.scala
+++ b/framework/arcane-framework/src/test/scala/services/connectors/mssql/MsSqlConnectorsTests.scala
@@ -51,6 +51,12 @@ class MsSqlConnectorsTests extends flatspec.AsyncFlatSpec with Matchers:
     for i <- 1 to 10 do
       val insertCmd = s"use arcane; insert into dbo.MsSqlConnectorsTests values($i, ${i+1})"
       statement.execute(insertCmd)
+    statement.close()
+
+    val updateStatement = con.createStatement()
+    for i <- 1 to 10 do
+      val insertCmd = s"use arcane; insert into dbo.MsSqlConnectorsTests values(${i * 1000}, ${i * 1000 + 1})"
+      updateStatement.execute(insertCmd)
 
 
   def removeDb(): Unit =
@@ -105,5 +111,28 @@ class MsSqlConnectorsTests extends flatspec.AsyncFlatSpec with Matchers:
     connection.getSchema map { schema =>
       val fields = for column <- schema if column.isInstanceOf[Field] yield column.fieldType
       fields should be(List(IntType, LongType, StringType, IntType, LongType, StringType, StringType))
+    }
+  }
+
+
+  "MsSqlConnection" should "return correct number of rows on backfill" in withDatabase { dbInfo =>
+    val connection = MsSqlConnection(dbInfo.connectionOptions)
+    for schema <- connection.getSchema
+        backfill <- connection.backfill(schema)
+        result = backfill.read.toList
+    yield {
+      result should have length 20
+    }
+  }
+
+
+  "MsSqlConnection" should "return correct number of columns on backfill" in withDatabase { dbInfo =>
+    val connection = MsSqlConnection(dbInfo.connectionOptions)
+    for schema <- connection.getSchema
+        backfill <- connection.backfill(schema)
+        result = backfill.read.toList
+        head = result.head
+    yield {
+      head should have length 7
     }
   }


### PR DESCRIPTION
## Scope

Part of #61

This PR implements the backfill behavior for MSSQL server client, where the client queries all data from the data source and returns this data as a LazyList.

NOTE: the `LazyList` class is used because the `Stream` class is deprecated.
NOTE2: in the *.sql files the invisible Byte Order Mark was removed.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.