### PR TITLE
Implement getChanges method for Arcane SQL server

### DIFF
--- a/framework/arcane-framework/src/main/scala/services/mssql/QueryRunner.scala
+++ b/framework/arcane-framework/src/main/scala/services/mssql/QueryRunner.scala
@@ -1,6 +1,8 @@
 package com.sneaksanddata.arcane.framework
 package services.mssql
 
+import services.mssql.base.QueryResult
+
 import java.sql.{Connection, ResultSet, Statement}
 import scala.concurrent.{Future, blocking}
 

--- a/framework/arcane-framework/src/main/scala/services/mssql/ScalarQueryResult.scala
+++ b/framework/arcane-framework/src/main/scala/services/mssql/ScalarQueryResult.scala
@@ -1,0 +1,51 @@
+package com.sneaksanddata.arcane.framework
+package services.mssql
+
+import models.{DataCell, DataRow}
+import services.mssql.MsSqlConnection.toArcaneType
+import services.mssql.base.{QueryResult, ResultSetOwner}
+
+import java.sql.{ResultSet, Statement}
+import scala.annotation.tailrec
+import scala.util.{Failure, Success, Try}
+
+type ResultConverter[Result] = ResultSet => Result
+
+/**
+ * Implementation of the [[QueryResult]] trait that reads the scalar result of a query.
+ *
+ * @param statement The statement used to execute the query.
+ * @param resultSet The result set of the query.
+ */
+class ScalarQueryResult[Result](val statement: Statement, resultSet: ResultSet, resultConverter: ResultConverter[Result])
+  extends QueryResult[Option[Result]] with ResultSetOwner:
+
+  /**
+   * Reads the result of the query.
+   *
+   * @return The result of the query.
+   */
+  override def read: this.OutputType =
+    resultSet.getMetaData.getColumnCount match
+      case 1 =>
+        if resultSet.next() then
+          Some(resultConverter(resultSet))
+        else
+          None
+      case _ => None
+
+
+/**
+ * Companion object for [[LazyQueryResult]].
+ */
+object ScalarQueryResult {
+  /**
+   * Creates a new [[LazyQueryResult]] object.
+   *
+   * @param statement The statement used to execute the query.
+   * @param resultSet The result set of the query.
+   * @return The new [[LazyQueryResult]] object.
+   */
+  def apply[Result](statement: Statement, resultSet: ResultSet, resultConverter: ResultConverter[Result]): ScalarQueryResult[Result] =
+    new ScalarQueryResult[Result](statement, resultSet, resultConverter)
+}

--- a/framework/arcane-framework/src/main/scala/services/mssql/ScalarQueryResult.scala
+++ b/framework/arcane-framework/src/main/scala/services/mssql/ScalarQueryResult.scala
@@ -9,6 +9,10 @@ import java.sql.{ResultSet, Statement}
 import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}
 
+/**
+ * Callback function that converts a result set to a result.
+ * @tparam Result The type of the result.
+ */
 type ResultConverter[Result] = ResultSet => Result
 
 /**

--- a/framework/arcane-framework/src/main/scala/services/mssql/base/QueryResult.scala
+++ b/framework/arcane-framework/src/main/scala/services/mssql/base/QueryResult.scala
@@ -1,0 +1,18 @@
+package com.sneaksanddata.arcane.framework
+package services.mssql.base
+
+/**
+ * Represents the result of a query to a SQL database.
+ */
+trait QueryResult[Output] {
+
+  type OutputType = Output
+
+  /**
+   * Reads the result of the SQL query mapped to an output type.
+   *
+   * @return The result of the query.
+   */
+  def read: OutputType
+
+}

--- a/framework/arcane-framework/src/main/scala/services/mssql/base/QueryResult.scala
+++ b/framework/arcane-framework/src/main/scala/services/mssql/base/QueryResult.scala
@@ -6,6 +6,9 @@ package services.mssql.base
  */
 trait QueryResult[Output] {
 
+  /**
+   * The output type of the query result.
+   */
   type OutputType = Output
 
   /**

--- a/framework/arcane-framework/src/main/scala/services/mssql/base/ResultSetOwner.scala
+++ b/framework/arcane-framework/src/main/scala/services/mssql/base/ResultSetOwner.scala
@@ -1,0 +1,17 @@
+package com.sneaksanddata.arcane.framework
+package services.mssql.base
+
+import java.sql.Statement
+
+/**
+ * AutoCloseable mixin for classes that own a result set.
+ */
+trait ResultSetOwner extends  AutoCloseable {
+  protected val statement: Statement
+
+  /**
+   * Closes the statement and the result set owned by this object.
+   * When a Statement object is closed, its current ResultSet object, if one exists, is also closed.
+   */
+  override def close(): Unit = statement.close()
+}

--- a/framework/arcane-framework/src/test/scala/services/connectors/mssql/MsSqlConnectorsTests.scala
+++ b/framework/arcane-framework/src/test/scala/services/connectors/mssql/MsSqlConnectorsTests.scala
@@ -3,7 +3,7 @@ package services.connectors.mssql
 
 import models.ArcaneType.{IntType, LongType, StringType}
 import models.Field
-import services.mssql.{ConnectionOptions, MsSqlConnection, QueryProvider}
+import services.mssql.{ConnectionOptions, MsSqlConnection, QueryProvider, QueryRunner}
 
 import com.microsoft.sqlserver.jdbc.SQLServerDriver
 import org.scalatest.*
@@ -21,6 +21,7 @@ case class TestConnectionInfo(connectionOptions: ConnectionOptions, connection: 
 
 class MsSqlConnectorsTests extends flatspec.AsyncFlatSpec with Matchers:
   implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+  private implicit val queryRunner: QueryRunner = QueryRunner()
   val connectionUrl = "jdbc:sqlserver://localhost;encrypt=true;trustServerCertificate=true;username=sa;password=tMIxN11yGZgMC"
 
   def createDb(): TestConnectionInfo =


### PR DESCRIPTION
Part of #61 

## Scope

Implemented:
- The `getChanges` method in the `MsSqlConnection` that reads changes from the database.

Additional changes:
- The `QueryRestult` trait was moved to another file
- The `ScalarQueryResult` class was addded
- The `AutoClosable` interface implementation was moved to the common trait `ResultSetOwner` from `QueryResult` implementations. 

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.