### PR TITLE
Fix issue when VersionedResult can lose first row of the data

### DIFF
--- a/framework/arcane-framework/src/main/scala/services/mssql/base/QueryResult.scala
+++ b/framework/arcane-framework/src/main/scala/services/mssql/base/QueryResult.scala
@@ -4,7 +4,7 @@ package services.mssql.base
 /**
  * Represents the result of a query to a SQL database.
  */
-trait QueryResult[Output] {
+trait QueryResult[Output]:
 
   /**
    * The output type of the query result.
@@ -18,4 +18,15 @@ trait QueryResult[Output] {
    */
   def read: OutputType
 
-}
+/**
+ * Represents a query result that can peek the head of the result.
+ *
+ * @tparam Output The type of the output of the query.
+ */
+trait CanPeekHead[Output]:
+  /**
+   * Peeks the head of the result of the SQL query mapped to an output type.
+   *
+   * @return The head of the result of the query.
+   */
+  def peekHead: QueryResult[Output] & CanPeekHead[Output]

--- a/framework/arcane-framework/src/main/scala/services/mssql/query/QueryRunner.scala
+++ b/framework/arcane-framework/src/main/scala/services/mssql/query/QueryRunner.scala
@@ -13,14 +13,14 @@ import scala.concurrent.{Future, blocking}
  * cursor.
  *
  */
-class QueryRunner:
+class QueryRunner[Output, QueryResultType <: QueryResult[Output]]:
   
   /**
    * A factory for creating a QueryResult object from a statement and a result set.
    *
    * @tparam Output The type of the output of the query.
    */
-  private type ResultFactory[Output] = (Statement, ResultSet) => QueryResult[Output]
+  private type ResultFactory = (Statement, ResultSet) => QueryResultType
   
   private implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
 
@@ -33,7 +33,7 @@ class QueryRunner:
    * @param connection The connection to execute the query on.
    * @return The result of the query.
    */
-  def executeQuery[Result](query: MsSqlQuery, connection: Connection, resultFactory: ResultFactory[Result]): Future[QueryResult[Result]] =
+  def executeQuery(query: MsSqlQuery, connection: Connection, resultFactory: ResultFactory): Future[QueryResultType] =
     Future {
     val statement = connection.createStatement()
     val resultSet = blocking {
@@ -44,4 +44,5 @@ class QueryRunner:
 
 
 object QueryRunner:
-  def apply(): QueryRunner = new QueryRunner()
+  def apply[O, T <: QueryResult[O]](): QueryRunner[O, T] = new QueryRunner[O, T]()
+  

--- a/framework/arcane-framework/src/main/scala/services/mssql/query/ScalarQueryResult.scala
+++ b/framework/arcane-framework/src/main/scala/services/mssql/query/ScalarQueryResult.scala
@@ -39,7 +39,6 @@ class ScalarQueryResult[Result](val statement: Statement, resultSet: ResultSet, 
           None
       case _ => None
 
-
 /**
  * Companion object for [[LazyQueryResult]].
  */

--- a/framework/arcane-framework/src/main/scala/services/streaming/StreamGraphBuilder.scala
+++ b/framework/arcane-framework/src/main/scala/services/streaming/StreamGraphBuilder.scala
@@ -5,7 +5,7 @@ import models.DataCell
 import services.mssql.MsSqlConnection
 import services.mssql.MsSqlConnection.VersionedBatch
 import services.mssql.query.LazyQueryResult.OutputType
-import services.mssql.query.QueryRunner
+import services.mssql.query.{LazyQueryResult, QueryRunner, ScalarQueryResult}
 import services.streaming.base.{HasVersion, StreamLifetimeService}
 
 import zio.stream.ZStream
@@ -36,7 +36,8 @@ given HasVersion[VersionedBatch] with
 
 
 class StreamGraphBuilder(msSqlConnection: MsSqlConnection) {
-  implicit val queryRunner: QueryRunner = QueryRunner()
+  implicit val dataQueryRunner: QueryRunner[LazyQueryResult.OutputType, LazyQueryResult] = QueryRunner()
+  implicit val versionQueryRunner: QueryRunner[Option[Long], ScalarQueryResult[Long]] = QueryRunner()
 
   /**
    * Builds a stream that reads the changes from the database.

--- a/framework/arcane-framework/src/test/scala/services/connectors/mssql/MsSqlConnectorsTests.scala
+++ b/framework/arcane-framework/src/test/scala/services/connectors/mssql/MsSqlConnectorsTests.scala
@@ -164,6 +164,6 @@ class MsSqlConnectorsTests extends flatspec.AsyncFlatSpec with Matchers:
         result <- connection.getChanges(None, Duration.ofDays(1))
         (_, latestVersion) = result
     yield {
-      latestVersion should be > 0L
+      latestVersion should be >= 0L
     }
   }

--- a/framework/arcane-framework/src/test/scala/services/connectors/mssql/MsSqlConnectorsTests.scala
+++ b/framework/arcane-framework/src/test/scala/services/connectors/mssql/MsSqlConnectorsTests.scala
@@ -3,7 +3,7 @@ package services.connectors.mssql
 
 import models.ArcaneType.{IntType, LongType, StringType}
 import models.Field
-import services.mssql.query.QueryRunner
+import services.mssql.query.{LazyQueryResult, QueryRunner, ScalarQueryResult}
 import services.mssql.{ConnectionOptions, MsSqlConnection, QueryProvider}
 
 import com.microsoft.sqlserver.jdbc.SQLServerDriver
@@ -21,36 +21,40 @@ import scala.language.postfixOps
 case class TestConnectionInfo(connectionOptions: ConnectionOptions, connection: Connection)
 
 class MsSqlConnectorsTests extends flatspec.AsyncFlatSpec with Matchers:
-  implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
-  private implicit val queryRunner: QueryRunner = QueryRunner()
+  private implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+  private implicit val dataQueryRunner: QueryRunner[LazyQueryResult.OutputType, LazyQueryResult] = QueryRunner()
+  private implicit val versionQueryRunner: QueryRunner[Option[Long], ScalarQueryResult[Long]] = QueryRunner()
+
   val connectionUrl = "jdbc:sqlserver://localhost;encrypt=true;trustServerCertificate=true;username=sa;password=tMIxN11yGZgMC"
 
-  def createDb(): TestConnectionInfo =
+  def createDb(tableName: String): TestConnectionInfo =
     val dr = new SQLServerDriver()
     val con = dr.connect(connectionUrl, new Properties())
     val query = "IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = 'arcane') BEGIN CREATE DATABASE arcane; alter database Arcane set CHANGE_TRACKING = ON (CHANGE_RETENTION = 2 DAYS, AUTO_CLEANUP = ON); END;"
     val statement = con.createStatement()
     statement.execute(query)
-    createTable(con)
+    createTable(tableName, con)
     TestConnectionInfo(
       ConnectionOptions(
         connectionUrl,
         "arcane",
         "dbo",
-        "MsSqlConnectorsTests",
+        tableName,
         Some("format(getdate(), 'yyyyMM')")), con)
 
-  def createTable(con: Connection): Unit =
-    val query = "use arcane; drop table if exists dbo.MsSqlConnectorsTests; create table dbo.MsSqlConnectorsTests(x int not null, y int)"
+  def createTable(tableName: String, con: Connection): Unit =
+    val query = s"use arcane; drop table if exists dbo.$tableName; create table dbo.$tableName (x int not null, y int)"
     val statement = con.createStatement()
     statement.executeUpdate(query)
 
-    val createPKCmd = "use arcane; alter table dbo.MsSqlConnectorsTests add constraint pk_MsSqlConnectorsTests primary key(x);"
+    val createPKCmd = s"use arcane; alter table dbo.$tableName add constraint pk_$tableName primary key(x);"
     statement.executeUpdate(createPKCmd)
 
-    val enableCtCmd = "use arcane; alter table dbo.MsSqlConnectorsTests enable change_tracking;"
+    val enableCtCmd = s"use arcane; alter table dbo.$tableName enable change_tracking;"
     statement.executeUpdate(enableCtCmd)
 
+  def insertData(con: Connection): Unit =
+    val statement = con.createStatement()
     for i <- 1 to 10 do
       val insertCmd = s"use arcane; insert into dbo.MsSqlConnectorsTests values($i, ${i+1})"
       statement.execute(insertCmd)
@@ -71,7 +75,12 @@ class MsSqlConnectorsTests extends flatspec.AsyncFlatSpec with Matchers:
 
 
   def withDatabase(test: TestConnectionInfo => Future[Assertion]): Future[Assertion] =
-    val conn = createDb()
+    val conn = createDb("MsSqlConnectorsTests")
+    insertData(conn.connection)
+    test(conn)
+
+  def withFreshTable(tableName: String)(test: TestConnectionInfo => Future[Assertion]): Future[Assertion] =
+    val conn = createDb(tableName)
     test(conn)
 
   "QueryProvider" should "generate columns query" in withDatabase { dbInfo =>

--- a/framework/arcane-framework/src/test/scala/services/streaming/StreamGraphBuilderTests.scala
+++ b/framework/arcane-framework/src/test/scala/services/streaming/StreamGraphBuilderTests.scala
@@ -96,8 +96,8 @@ class StreamGraphBuilderTests extends flatspec.AsyncFlatSpec with Matchers:
 
     Unsafe.unsafe { implicit unsafe => runtime.unsafe.runToFuture(zio) } flatMap { list =>
       list should have size 3 // 3 batches of changes
-      list map (_.size) should contain theSameElementsAs List(9, 0, 0) // only first batch has data
-      list.head.size should be (9) // 7 fields in the first batch
+      list map (_.size) should contain theSameElementsAs List(10, 0, 0) // only first batch has data
+      list.head.size should be (10) // 7 fields in the first batch
     }
   }
 
@@ -118,7 +118,7 @@ class StreamGraphBuilderTests extends flatspec.AsyncFlatSpec with Matchers:
 
     Unsafe.unsafe { implicit unsafe => runtime.unsafe.runToFuture(zio) } flatMap { list  =>
       list must have size 3 // 3 batches of changes
-      list map(_.size) must contain only 9 // rows changes in each batch
+      list map(_.size) must contain only 10 // rows changes in each batch
       list.flatMap(_.map(_.size)) must contain only 7 // 7 fields in each row
     }
   }

--- a/framework/arcane-framework/src/test/scala/services/streaming/StreamGraphBuilderTests.scala
+++ b/framework/arcane-framework/src/test/scala/services/streaming/StreamGraphBuilderTests.scala
@@ -1,7 +1,7 @@
 package com.sneaksanddata.arcane.framework
 package services.streaming
 
-import services.mssql.query.QueryRunner
+import services.mssql.query.{LazyQueryResult, QueryRunner, ScalarQueryResult}
 import services.mssql.{ConnectionOptions, MsSqlConnection}
 import services.streaming.base.StreamLifetimeService
 
@@ -9,6 +9,7 @@ import com.microsoft.sqlserver.jdbc.SQLServerDriver
 import org.scalatest.*
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers.*
+import zio.stream.ZSink
 import zio.{Runtime, Unsafe}
 
 import java.sql.Connection
@@ -16,22 +17,24 @@ import java.util.Properties
 import scala.List
 import scala.concurrent.Future
 import scala.language.postfixOps
+import scala.util.Using
 
 case class TestConnectionInfo(connectionOptions: ConnectionOptions, connection: Connection)
 
 class StreamGraphBuilderTests extends flatspec.AsyncFlatSpec with Matchers:
-  implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
-  private implicit val queryRunner: QueryRunner = QueryRunner()
+  private implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+  private implicit val dataQueryRunner: QueryRunner[LazyQueryResult.OutputType, LazyQueryResult] = QueryRunner()
+  private implicit val versionQueryRunner: QueryRunner[Option[Long], ScalarQueryResult[Long]] = QueryRunner()
   private val connectionUrl = "jdbc:sqlserver://localhost;encrypt=true;trustServerCertificate=true;username=sa;password=tMIxN11yGZgMC;databaseName=arcane"
   private val runtime = Runtime.default
 
-  def createDb(): TestConnectionInfo =
+  def createDb(tableName: String): TestConnectionInfo =
     val dr = new SQLServerDriver()
     val con = dr.connect(connectionUrl, new Properties())
     val query = "IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = 'arcane') BEGIN CREATE DATABASE arcane; alter database Arcane set CHANGE_TRACKING = ON (CHANGE_RETENTION = 2 DAYS, AUTO_CLEANUP = ON); END;"
     val statement = con.createStatement()
     statement.execute(query)
-    createTable(con)
+    createTable(con, tableName)
     TestConnectionInfo(
       ConnectionOptions(
         connectionUrl,
@@ -40,24 +43,27 @@ class StreamGraphBuilderTests extends flatspec.AsyncFlatSpec with Matchers:
         "StreamGraphBuilderTests",
         Some("format(getdate(), 'yyyyMM')")), con)
 
-  def createTable(con: Connection): Unit =
-    val query = "use arcane; drop table if exists dbo.StreamGraphBuilderTests; create table dbo.StreamGraphBuilderTests(x int not null, y int)"
+  def insertData(con: Connection, tableName: String): Unit =
+    val sql = s"use arcane; insert into dbo.$tableName values(?, ?)";
+    Using(con.prepareStatement(sql)) { insertStatement =>
+      for i <- 0 to 9 do
+        insertStatement.setInt(1, i)
+        insertStatement.setInt(2, i + 1)
+        insertStatement.addBatch()
+        insertStatement.clearParameters()
+      insertStatement.executeBatch()
+    }
+
+  def createTable(con: Connection, tableName: String): Unit =
+    val query = s"use arcane; drop table if exists dbo.$tableName; create table dbo.StreamGraphBuilderTests(x int not null, y int)"
     val statement = con.createStatement()
     statement.executeUpdate(query)
 
-    val createPKCmd = "use arcane; alter table dbo.StreamGraphBuilderTests add constraint pk_StreamGraphBuilderTests primary key(x);"
+    val createPKCmd = s"use arcane; alter table dbo.$tableName add constraint pk_StreamGraphBuilderTests primary key(x);"
     statement.executeUpdate(createPKCmd)
 
-    val enableCtCmd = "use arcane; alter table dbo.StreamGraphBuilderTests enable change_tracking;"
+    val enableCtCmd = s"use arcane; alter table dbo.$tableName enable change_tracking;"
     statement.executeUpdate(enableCtCmd)
-
-    val insertStatement = con.prepareStatement("use arcane; insert into dbo.StreamGraphBuilderTests values(?, ?)")
-    for i <- 0 to 9 do
-      insertStatement.setInt(1, i)
-      insertStatement.setInt(2, i + 1)
-      insertStatement.addBatch()
-      insertStatement.clearParameters()
-    insertStatement.executeBatch()
     statement.close()
 
 
@@ -69,12 +75,18 @@ class StreamGraphBuilderTests extends flatspec.AsyncFlatSpec with Matchers:
     statement.execute(query)
 
 
-  def withFreshDatabase(test: TestConnectionInfo => Future[Assertion]): Future[Assertion] =
+  def withFreshTable(tableName: String)(test: TestConnectionInfo => Future[Assertion]): Future[Assertion] =
     removeDb()
-    val conn = createDb()
+    val conn = createDb(tableName)
+    insertData(conn.connection, tableName)
     test(conn)
 
-  "StreamGraph" should "not duplicate data on the first iteration" in withFreshDatabase { dbInfo =>
+  def withEmptyTable(tableName: String)(test: TestConnectionInfo => Future[Assertion]): Future[Assertion] =
+    removeDb()
+    val conn = createDb(tableName)
+    test(conn)
+
+  "StreamGraph" should "not duplicate data on the first iteration" in withFreshTable("StreamGraphBuilderTests") { dbInfo =>
     val streamGraphBuilder = new StreamGraphBuilder(MsSqlConnection(dbInfo.connectionOptions))
 
     val lifetime = TestStreamLifetimeService(3)
@@ -89,7 +101,7 @@ class StreamGraphBuilderTests extends flatspec.AsyncFlatSpec with Matchers:
     }
   }
 
-  "StreamGraph" should "be able to generate changes stream" in withFreshDatabase { dbInfo =>
+  "StreamGraph" should "be able to generate changes stream" in withFreshTable("StreamGraphBuilderTests") { dbInfo =>
     val streamGraphBuilder = new StreamGraphBuilder(MsSqlConnection(dbInfo.connectionOptions))
 
     val lifetime = TestStreamLifetimeService(3, counter => {


### PR DESCRIPTION
Part of #61

This PR fixes the issue which can occur when the method `getLatestVersion` of the `HasVersion` typeclass peeks the first element of the `VersionedBatch`.

In this case the stateful `ResultSet` inside this class moves forward and the first row of the set is being lost.

To avoid this issue, the `CanPeekHead` trait was added. The implementation of this trait saves the first row of the `ResultSet` if the head of the `ResultSet` was requested.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.