### PR TITLE
Enable docker build for scala code

### DIFF
--- a/.container/Dockerfile
+++ b/.container/Dockerfile
@@ -1,2 +1,15 @@
-﻿FROM scratch
+﻿FROM --platform=$BUILDPLATFORM sbtscala/scala-sbt:eclipse-temurin-23.0.1_11_1.10.5_3.5.2 AS build
+
 WORKDIR /
+
+COPY . .
+
+WORKDIR /plugin/arcane-stream-sqlserver-change-tracking
+
+RUN sbt assembly
+
+FROM --platform=$BUILDPLATFORM gcr.io/distroless/java-base-debian12
+
+COPY --from=build /plugin/arcane-stream-sqlserver-change-tracking/target/scala-3.6.1 /app
+
+CMD ["java", "-jar", "/app/com.sneaksanddata.arcane.sql-server-change-tracking.assembly.jar"]

--- a/.github/workflows/build-scala.yaml
+++ b/.github/workflows/build-scala.yaml
@@ -43,7 +43,7 @@ jobs:
     name: Build Docker Image and Helm Charts
     runs-on: ubuntu-latest
     needs: [ validate_commit ]
-    if: ${{ false && (needs.validate_commit.result == 'success' || needs.validate_commit.result == 'skipped') }}
+    if: ${{ needs.validate_commit.result == 'success' || needs.validate_commit.result == 'skipped' }}
     permissions:
       contents: read
       packages: write

--- a/plugin/arcane-stream-sqlserver-change-tracking/build.sbt
+++ b/plugin/arcane-stream-sqlserver-change-tracking/build.sbt
@@ -4,6 +4,7 @@ ThisBuild / version := "0.1.0-SNAPSHOT"
 ThisBuild / trackInternalDependencies := TrackLevel.TrackIfMissing
 ThisBuild / exportJars := true
 ThisBuild / scalaVersion := "3.6.1"
+ThisBuild / organization := "com.sneaksanddata"
 
 
 
@@ -14,6 +15,20 @@ lazy val plugin = (project in file("."))
     libraryDependencies += "dev.zio" %% "zio-json" % "0.6.2",
     libraryDependencies += "dev.zio" %% "zio-logging" % "2.3.0",
     libraryDependencies += "dev.zio" %% "zio-logging-slf4j" % "2.2.4",
-    libraryDependencies += "org.slf4j" % "slf4j-simple" % "1.7.36"
+    libraryDependencies += "org.slf4j" % "slf4j-simple" % "1.7.36",
+    assembly / mainClass := Some("com.sneaksanddata.arcane.sql_server_change_tracking.main"),
+
+    // We do not use the version name here, because it's executable file name
+    // and we want to keep it consistent with the name of the project
+    assembly / assemblyJarName := "com.sneaksanddata.arcane.sql-server-change-tracking.assembly.jar",
+
+    assembly / assemblyMergeStrategy := {
+        // Removes duplicate files from META-INF
+        // Mostly io.netty.versions.properties, license files, INDEX.LIST, MANIFEST.MF, etc.
+        case PathList("META-INF", _) => MergeStrategy.discard
+
+        // For other files we use the default strategy (deduplicate)
+        case x => MergeStrategy.deduplicate
+    }
   )
   .dependsOn(ProjectRef(file("../../framework/arcane-framework"), "root"))

--- a/plugin/arcane-stream-sqlserver-change-tracking/project/plugins.sbt
+++ b/plugin/arcane-stream-sqlserver-change-tracking/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("org.jetbrains.scala" % "sbt-ide-settings" % "1.1.2")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.0")


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/arcane-stream-sqlserver-change-tracking/issues/61

## Scope

Implemented:
- This PR introduces the Dockerfile for new Scala plugin based on Distroless Java images (see: https://github.com/GoogleContainerTools/distroless)

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.