### PR TITLE
Implement implicit conversion in the convenient way

### DIFF
--- a/framework/arcane-framework/src/main/scala/services/lakehouse/IcebergS3CatalogWriter.scala
+++ b/framework/arcane-framework/src/main/scala/services/lakehouse/IcebergS3CatalogWriter.scala
@@ -1,7 +1,7 @@
 package com.sneaksanddata.arcane.framework
 package services.lakehouse
 
-import models.{ArcaneSchema, DataRow}
+import models.DataRow
 import services.lakehouse.base.IcebergCatalogSettings
 
 import org.apache.iceberg.aws.s3.S3FileIOProperties
@@ -20,11 +20,6 @@ import scala.jdk.CollectionConverters.*
 import scala.language.implicitConversions
 import scala.util.{Failure, Success, Try}
 
-/**
- * Converts an Arcane schema to an Iceberg schema.
- */
-given Conversion[ArcaneSchema, Schema] with
-  def apply(schema: ArcaneSchema): Schema = SchemaConversions.toIcebergSchema(schema)
   
 // https://www.tabular.io/blog/java-api-part-3/
 class IcebergS3CatalogWriter(

--- a/framework/arcane-framework/src/main/scala/services/lakehouse/SchemaConversions.scala
+++ b/framework/arcane-framework/src/main/scala/services/lakehouse/SchemaConversions.scala
@@ -1,20 +1,18 @@
 package com.sneaksanddata.arcane.framework
 package services.lakehouse
 
-import models.{ArcaneSchema, ArcaneSchemaField, ArcaneType}
 import models.ArcaneType.*
+import models.{ArcaneSchema, ArcaneType}
 
 import org.apache.iceberg.Schema
-import org.apache.iceberg.types.Types
-
-import scala.language.implicitConversions
+import org.apache.iceberg.types.{Type, Types}
 import scala.jdk.CollectionConverters.*
 
 /**
- * Implicit conversions from ArcaneType to Iceberg schema types
+ * Converts an Arcane schema to an Iceberg schema.
  */
-object SchemaConversions:
-  implicit def toIcebergType(arcaneType: ArcaneType): org.apache.iceberg.types.Type = arcaneType match
+given Conversion[ArcaneType, Type] with
+  def apply(arcaneType:  ArcaneType): Type = arcaneType match
     case IntType => Types.IntegerType.get()
     case LongType => Types.LongType.get()
     case ByteArrayType => Types.BinaryType.get()
@@ -29,13 +27,15 @@ object SchemaConversions:
     case ShortType => Types.IntegerType.get()
     case TimeType => Types.TimeType.get()
 
-  implicit def toIcebergSchema(schema: ArcaneSchema): Schema = new Schema(
+/**
+ * Converts an Arcane schema to an Iceberg schema.
+ */
+given Conversion[ArcaneSchema, Schema] with
+  def apply(schema: ArcaneSchema): Schema = new Schema(
     schema
       .zipWithIndex
       .map {
-        (field, index) => 
+        (field, index) =>
           Types.NestedField.optional(index, field.name, field.fieldType)
       }.asJava
   )
-
-  implicit def toIcebergSchemaFromFields(fields: Seq[ArcaneSchemaField]): Schema = toIcebergSchema(fields)

--- a/framework/arcane-framework/src/main/scala/services/mssql/MsSqlConnection.scala
+++ b/framework/arcane-framework/src/main/scala/services/mssql/MsSqlConnection.scala
@@ -204,7 +204,8 @@ object MsSqlConnection:
 
   /**
    * Converts a SQL type to an Arcane type.
-   *
+   * This method is not the implementation of th Conversion typeclass since Int is a very broad type
+   * and explicit conversion could be error-prone
    * @param sqlType The SQL type.
    * @return The Arcane type.
    */

--- a/framework/arcane-framework/src/test/scala/services/lakehouse/IcebergS3CatalogWriterTests.scala
+++ b/framework/arcane-framework/src/test/scala/services/lakehouse/IcebergS3CatalogWriterTests.scala
@@ -2,7 +2,7 @@ package com.sneaksanddata.arcane.framework
 package services.lakehouse
 
 import models.ArcaneType.{IntType, StringType}
-import models.{DataCell, Field, MergeKeyField}
+import models.{ArcaneSchema, DataCell, Field, MergeKeyField}
 import services.lakehouse.base.IcebergCatalogSettings
 
 import org.scalatest.*
@@ -13,7 +13,6 @@ import java.util.UUID
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters.*
 import scala.language.postfixOps
-import services.lakehouse.SchemaConversions.*
 
 class IcebergS3CatalogWriterTests extends flatspec.AsyncFlatSpec with Matchers:
   private implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
@@ -25,7 +24,7 @@ class IcebergS3CatalogWriterTests extends flatspec.AsyncFlatSpec with Matchers:
     override val s3CatalogFileIO: S3CatalogFileIO = S3CatalogFileIO
     override val stagingLocation: Option[String] = Some("s3://tmp/polaris/test")
 
-  private val schema = Seq(MergeKeyField, Field(name = "colA", fieldType = IntType), Field(name = "colB", fieldType = StringType))
+  private val schema: ArcaneSchema = Seq(MergeKeyField, Field(name = "colA", fieldType = IntType), Field(name = "colB", fieldType = StringType))
   private val icebergWriter = IcebergS3CatalogWriter(settings)
 
   it should "create a table when provided schema and rows" in {


### PR DESCRIPTION
Part of SneaksAndData/arcane-framework-scala#75 

## Scope

In this pull request the `SchemaConversions` object is being replaced with a more convenient way to convert types using the `Conversion` typeclass.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.