### PR TITLE
Add ability to write staging queries in backfill mode

### DIFF
--- a/framework/arcane-framework/src/main/scala/services/streaming/BackfillGroupingProcessor.scala
+++ b/framework/arcane-framework/src/main/scala/services/streaming/BackfillGroupingProcessor.scala
@@ -3,15 +3,12 @@ package services.streaming
 
 import models.DataRow
 import models.settings.GroupingSettings
-import services.mssql.MsSqlConnection.BackfillBatch
 import services.streaming.base.BatchProcessor
 
-import zio.stream.{ZPipeline, ZStream}
-import zio.{Chunk, Scope, ZIO, ZLayer}
+import zio.stream.ZPipeline
+import zio.{Chunk, ZIO, ZLayer}
 
-import java.sql.SQLException
 import scala.concurrent.duration.Duration
-import scala.util.{Try, Using}
 
 /**
  * The batch processor implementation that converts a lazy DataBatch to a Chunk of DataRow.

--- a/plugin/arcane-stream-sqlserver-change-tracking/src/main/scala/main.scala
+++ b/plugin/arcane-stream-sqlserver-change-tracking/src/main/scala/main.scala
@@ -10,7 +10,6 @@ import com.sneaksanddata.arcane.framework.services.app.base.{StreamLifetimeServi
 import com.sneaksanddata.arcane.framework.services.app.logging.base.Enricher
 import com.sneaksanddata.arcane.framework.services.app.{PosixStreamLifetimeService, StreamRunnerServiceImpl}
 import com.sneaksanddata.arcane.framework.services.lakehouse.IcebergS3CatalogWriter
-import com.sneaksanddata.arcane.framework.services.mssql.MsSqlConnection.BackfillBatch
 import com.sneaksanddata.arcane.framework.services.mssql.{ConnectionOptions, MsSqlConnection, MsSqlDataProvider}
 import com.sneaksanddata.arcane.framework.services.streaming.base.{BatchProcessor, StreamGraphBuilder}
 import com.sneaksanddata.arcane.framework.services.streaming.{BackfillGroupingProcessor, IcebergConsumer, LazyListGroupingProcessor}


### PR DESCRIPTION
Part of #61

## Scope

Implemented:
- Implement ability to write staging tables in backfill mode

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.