### PR TITLE
Implement Backfill data consumer

### DIFF
--- a/framework/arcane-framework/src/main/scala/services/mssql/MsSqlConnection.scala
+++ b/framework/arcane-framework/src/main/scala/services/mssql/MsSqlConnection.scala
@@ -126,10 +126,19 @@ class MsSqlConnection(val connectionOptions: ConnectionOptions) extends AutoClos
 
   /**
    * Gets the schema for the data produced by Arcane.
+   * Implementation in the MsSqlConnection memorizes the schema since we need to run an SQL query to 
+   * get the schema.
    *
    * @return A future containing the schema for the data produced by Arcane.
    */
-  override def getSchema: Future[this.SchemaType] =
+  override lazy val getSchema: Future[this.SchemaType] = readSchemaFromSource
+
+  /**
+   * Gets the schema for the data produced by Arcane.
+   *
+   * @return A future containing the schema for the data produced by Arcane.
+   */
+  private def readSchemaFromSource: Future[this.SchemaType] =
     for query <- this.getSchemaQuery
         sqlSchema <- getSqlSchema(query)
     yield toSchema(sqlSchema, empty) match

--- a/framework/arcane-framework/src/main/scala/services/streaming/base/StreamGraphBuilder.scala
+++ b/framework/arcane-framework/src/main/scala/services/streaming/base/StreamGraphBuilder.scala
@@ -2,6 +2,7 @@ package com.sneaksanddata.arcane.framework
 package services.streaming.base
 
 import zio.stream.{ZSink, ZStream}
+import zio.{Task, ZIO}
 
 /**
  * A trait that represents a stream graph builder.
@@ -26,3 +27,10 @@ trait StreamGraphBuilder:
    * @return ZStream (stream source for the stream graph).
    */
   def consume: ZSink[Any, Throwable, StreamElementType, Any, Unit]
+  
+  /**
+   * The action to perform when the stream completes.
+   *
+   * @return A task that represents the action to perform when the stream completes.
+   */
+  def onComplete: Task[Unit] = ZIO.unit

--- a/framework/arcane-framework/src/main/scala/services/streaming/consumers/IcebergBackfillConsumer.scala
+++ b/framework/arcane-framework/src/main/scala/services/streaming/consumers/IcebergBackfillConsumer.scala
@@ -1,0 +1,103 @@
+package com.sneaksanddata.arcane.framework
+package services.streaming.consumers
+
+import models.app.StreamContext
+import models.settings.SinkSettings
+import models.{ArcaneSchema, DataRow}
+import services.base.SchemaProvider
+import services.consumers.StagedVersionedBatch
+import services.lakehouse.{CatalogWriter, given_Conversion_ArcaneSchema_Schema}
+import services.streaming.base.{BatchConsumer, BatchProcessor}
+import services.streaming.consumers.IcebergBackfillConsumer.getTableName
+
+import org.apache.iceberg.rest.RESTCatalog
+import org.apache.iceberg.{Schema, Table}
+import org.slf4j.{Logger, LoggerFactory}
+import zio.stream.ZSink
+import zio.{Chunk, ZIO, ZLayer}
+
+/**
+ * A trait that represents a streaming consumer.
+ */
+trait BackfillConsumer extends BatchConsumer[Chunk[DataRow]]
+
+/**
+ * A consumer that writes the data to the staging table.
+ *
+ * @param streamContext  The stream context.
+ * @param catalogWriter  The catalog writer.
+ * @param schemaProvider The schema provider.
+ */
+class IcebergBackfillConsumer(streamContext: StreamContext,
+                               sinkSettings: SinkSettings,
+                               catalogWriter: CatalogWriter[RESTCatalog, Table, Schema],
+                               schemaProvider: SchemaProvider[ArcaneSchema]) extends BackfillConsumer:
+
+  private val logger: Logger = LoggerFactory.getLogger(classOf[IcebergBackfillConsumer])
+
+  private val tableName = getTableName(streamContext.streamId)
+
+  /**
+   * Returns the sink that consumes the batch.
+   *
+   * @return ZSink (stream sink for the stream graph).
+   */
+  def consume: ZSink[Any, Throwable, Chunk[DataRow], Any, Unit] = ZSink.foldLeftZIO(false) { (tableExists: Boolean, rows: Chunk[DataRow]) =>
+    if tableExists then
+      writeWithWriter(rows, tableName)
+    else
+      createTable(rows, tableName)
+  }.map(_ => ())
+
+  private def createTable(rows: Chunk[DataRow], name: String): ZIO[Any, Throwable, Boolean] =
+    for
+      arcaneSchema <- ZIO.fromFuture(implicit ec => schemaProvider.getSchema)
+      table <- ZIO.fromFuture(implicit ec => catalogWriter.write(rows, name, arcaneSchema))
+    yield true
+    
+  private def writeWithWriter(rows: Chunk[DataRow], name: String): ZIO[Any, Throwable, Boolean] =
+    for
+      arcaneSchema <- ZIO.fromFuture(implicit ec => schemaProvider.getSchema)
+      table <- ZIO.fromFuture(implicit ec => catalogWriter.append(rows, name, arcaneSchema))
+    yield true
+
+object IcebergBackfillConsumer:
+  def getTableName(streamId: String): String = s"${streamId}_backfill"
+
+
+  /**
+   * Factory method to create IcebergConsumer
+   *
+   * @param streamContext  The stream context.
+   * @param sinkSettings   The stream sink settings.
+   * @param catalogWriter  The catalog writer.
+   * @param schemaProvider The schema provider.
+   * @return The initialized IcebergConsumer instance
+   */
+  def apply(streamContext: StreamContext,
+            sinkSettings: SinkSettings,
+            catalogWriter: CatalogWriter[RESTCatalog, Table, Schema],
+            schemaProvider: SchemaProvider[ArcaneSchema]): IcebergBackfillConsumer =
+    new IcebergBackfillConsumer(streamContext, sinkSettings, catalogWriter, schemaProvider)
+
+  /**
+   * The required environment for the IcebergConsumer.
+   */
+  type Environment = SchemaProvider[ArcaneSchema]
+    & CatalogWriter[RESTCatalog, Table, Schema]
+    & BatchProcessor[StagedVersionedBatch, Boolean]
+    & StreamContext
+    & SinkSettings
+
+  /**
+   * The ZLayer that creates the IcebergConsumer.
+   */
+  val layer: ZLayer[Environment, Nothing, BackfillConsumer] =
+    ZLayer {
+      for
+        streamContext <- ZIO.service[StreamContext]
+        sinkSettings <- ZIO.service[SinkSettings]
+        catalogWriter <- ZIO.service[CatalogWriter[RESTCatalog, Table, Schema]]
+        schemaProvider <- ZIO.service[SchemaProvider[ArcaneSchema]]
+      yield IcebergBackfillConsumer(streamContext, sinkSettings, catalogWriter, schemaProvider)
+    }

--- a/plugin/arcane-stream-sqlserver-change-tracking/src/main/scala/main.scala
+++ b/plugin/arcane-stream-sqlserver-change-tracking/src/main/scala/main.scala
@@ -13,7 +13,7 @@ import com.sneaksanddata.arcane.framework.services.consumers.JdbcConsumer
 import com.sneaksanddata.arcane.framework.services.lakehouse.IcebergS3CatalogWriter
 import com.sneaksanddata.arcane.framework.services.mssql.{ConnectionOptions, MsSqlConnection, MsSqlDataProvider}
 import com.sneaksanddata.arcane.framework.services.streaming.base.{BatchProcessor, StreamGraphBuilder}
-import com.sneaksanddata.arcane.framework.services.streaming.consumers.IcebergConsumer
+import com.sneaksanddata.arcane.framework.services.streaming.consumers.{IcebergBackfillConsumer, IcebergStreamingConsumer}
 import com.sneaksanddata.arcane.framework.services.streaming.processors.{BackfillGroupingProcessor, LazyListGroupingProcessor, MergeProcessor}
 import org.slf4j.MDC
 import zio.logging.LogFormat
@@ -53,9 +53,9 @@ object main extends ZIOAppDefault {
       StreamGraphBuilderFactory.layer,
       BackfillGroupingProcessor.layer,
       IcebergS3CatalogWriter.layer,
-      IcebergConsumer.layer,
+      IcebergStreamingConsumer.layer,
       MergeProcessor.layer,
-      JdbcConsumer.layer
-    )
+      JdbcConsumer.layer,
+      IcebergBackfillConsumer.layer)
     .orDie
 }


### PR DESCRIPTION
Part of #61

## Scope

Implemented:
- BackfillConsumer class that creates a staging table for backfill job runs.

Additional changes:
- The type of the `SYS_CHANGE_VERSION` value placeholder in backfill data batches was changed from `int` to `long` to match the schema.
- The `QueryProvider` class logs the queries before execution
- Added memoization for the `getSchema` call in the `MsSqlConnection` class.
- Added abstract `onComplete` method in the StreamGraphBuilder class

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.