### PR TITLE
Add the integration tests that verify the schema evolution

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,8 @@ lazy val plugin = (project in file("."))
     // Test dependencies
     libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19" % Test,
     libraryDependencies += "org.scalatest" %% "scalatest-flatspec" % "3.2.19" % Test,
+    libraryDependencies += "dev.zio" %% "zio-test"          % "2.1.16" % Test,
+    libraryDependencies += "dev.zio" %% "zio-test-sbt"      % "2.1.16" % Test,
 
     assembly / mainClass := Some("com.sneaksanddata.arcane.sql_server_change_tracking.main"),
 

--- a/src/test/scala/tests/common/Common.scala
+++ b/src/test/scala/tests/common/Common.scala
@@ -169,7 +169,7 @@ object Common:
    */
   def addColumns(connection: Connection, tableName: String, migrationExpression: String): ZIO[Any, Throwable, Unit] = ZIO.scoped {
     for
-      statement <- ZIO.attempt(connection.prepareStatement(s"ALTER TABLE $tableName ADD $migrationExpression"))
+      statement <- ZIO.fromAutoCloseable(ZIO.attempt(connection.prepareStatement(s"ALTER TABLE $tableName ADD $migrationExpression")))
       _ <- ZIO.attempt(statement.execute())
     yield ()
   }
@@ -184,7 +184,7 @@ object Common:
    */
   def removeColumns(connection: Connection, tableName: String, migrationExpression: String): ZIO[Any, Throwable, Unit] = ZIO.scoped {
     for
-      statement <- ZIO.attempt(connection.prepareStatement(s"ALTER TABLE $tableName DROP COLUMN $migrationExpression"))
+      statement <- ZIO.fromAutoCloseable(ZIO.attempt(connection.prepareStatement(s"ALTER TABLE $tableName DROP COLUMN $migrationExpression")))
       _ <- ZIO.attempt(statement.execute())
     yield ()
   }

--- a/src/test/scala/tests/integration/Fixtures.scala
+++ b/src/test/scala/tests/integration/Fixtures.scala
@@ -2,6 +2,7 @@ package com.sneaksanddata.arcane.sql_server_change_tracking
 package tests.integration
 
 import org.scalatest.Assertion
+import zio.ZIO
 
 import java.sql.{Connection, DriverManager}
 import scala.concurrent.Future
@@ -11,8 +12,11 @@ object Fixtures:
   val connectionString: String = sys.env("ARCANE__CONNECTIONSTRING")
   val trinoConnectionString: String = sys.env("ARCANE_FRAMEWORK__MERGE_SERVICE_CONNECTION_URI")
 
+  def getConnection: Connection =
+    DriverManager.getConnection(connectionString)
+
   def createFreshSource(tableName: String): Connection  =
-    val con = DriverManager.getConnection(connectionString)
+    val con = getConnection
     val query = s"use IntegrationTests; drop table if exists dbo.$tableName; create table dbo.$tableName (Id int not null, Name nvarchar(10) not null)"
     val statement = con.createStatement()
     statement.executeUpdate(query)
@@ -35,3 +39,8 @@ object Fixtures:
   def withFreshTables(sourceTableName: String, targetTableName: String)(test: Connection => Future[Assertion]): Future[Assertion] =
     clearTarget(targetTableName)
     test(createFreshSource(sourceTableName))
+
+  def withFreshTablesZIO(sourceTableName: String, targetTableName: String): ZIO[Any, Nothing, Unit] =
+    for _ <- ZIO.succeed(createFreshSource(sourceTableName))
+        _   <- ZIO.succeed(clearTarget(targetTableName))
+    yield ()

--- a/src/test/scala/tests/integration/SchemaMigrationTests.scala
+++ b/src/test/scala/tests/integration/SchemaMigrationTests.scala
@@ -95,9 +95,8 @@ object SchemaMigrationTests extends ZIOSpecDefault:
 
         lifetimeService = ZLayer.succeed(TimeLimitLifetimeService(Duration.ofSeconds(15)))
         streamRunner <- Common.buildTestApp(lifetimeService, streamingStreamContextLayer).fork
-        _ <- ZIO.sleep(Duration.ofSeconds(10))
         _ <- Common.insertData(sourceConnection, sourceTableName, streamingData)
-        _ <- ZIO.sleep(Duration.ofSeconds(5))
+        _ <- ZIO.sleep(Duration.ofSeconds(15))
 
         _ <- ZIO.log("Checking if the data is in the target table")
         beforeEvolution <- Common.getData(

--- a/src/test/scala/tests/integration/SchemaMigrationTests.scala
+++ b/src/test/scala/tests/integration/SchemaMigrationTests.scala
@@ -105,6 +105,7 @@ object SchemaMigrationTests extends ZIOSpecDefault:
 
         _ <- ZIO.sleep(Duration.ofSeconds(5))
         _ <- Common.addColumns(sourceConnection, sourceTableName, "NewName VARCHAR(100)")
+        _ <- ZIO.sleep(Duration.ofSeconds(1))
         _ <- Common.insertUpdatedData(sourceConnection, sourceTableName, afterEvolution)
 
         _ <- streamRunner.await.timeout(Duration.ofSeconds(15))

--- a/src/test/scala/tests/integration/SchemaMigrationTests.scala
+++ b/src/test/scala/tests/integration/SchemaMigrationTests.scala
@@ -83,7 +83,7 @@ object SchemaMigrationTests extends ZIOSpecDefault:
 
   def spec: Spec[TestEnvironment & Scope, Throwable] = suite("StreamRunner") (
 
-    test("handle schema migration (column insertions)") {
+    test("handle the schema migration (column insertions)") {
       val streamingData = List.range(1, 4).map(i => (i, s"Test$i"))
       val afterEvolution = List.range(4, 7).map(i => (i, s"Test$i", s"Updated $i"))
 
@@ -96,8 +96,9 @@ object SchemaMigrationTests extends ZIOSpecDefault:
         lifetimeService = ZLayer.succeed(TimeLimitLifetimeService(Duration.ofSeconds(15)))
         streamRunner <- Common.buildTestApp(lifetimeService, streamingStreamContextLayer).fork
         _ <- Common.insertData(sourceConnection, sourceTableName, streamingData)
-        _ <- ZIO.sleep(Duration.ofSeconds(5))
+        _ <- ZIO.sleep(Duration.ofSeconds(15))
 
+        _ <- ZIO.log("Checking if the data is in the target table")
         beforeEvolution <- Common.getData(
           streamingStreamContext.targetTableFullName,
           "Id, Name",
@@ -118,7 +119,7 @@ object SchemaMigrationTests extends ZIOSpecDefault:
       } yield assertTrue(beforeEvolution.sorted == streamingData) && assertTrue(afterStream.sorted == afterEvolutionExpected)
     },
 
-    test("handle schema migration (column deletions)") {
+    test("handle the schema migration (column deletions)") {
       val streamingData = List.range(1, 4).map(i => (i, s"Test$i", s"Updated $i"))
       val afterEvolution = List.range(4, 7).map(i => (i, s"Test$i"))
 

--- a/src/test/scala/tests/integration/SchemaMigrationTests.scala
+++ b/src/test/scala/tests/integration/SchemaMigrationTests.scala
@@ -95,8 +95,9 @@ object SchemaMigrationTests extends ZIOSpecDefault:
 
         lifetimeService = ZLayer.succeed(TimeLimitLifetimeService(Duration.ofSeconds(15)))
         streamRunner <- Common.buildTestApp(lifetimeService, streamingStreamContextLayer).fork
+        _ <- ZIO.sleep(Duration.ofSeconds(10))
         _ <- Common.insertData(sourceConnection, sourceTableName, streamingData)
-        _ <- ZIO.sleep(Duration.ofSeconds(15))
+        _ <- ZIO.sleep(Duration.ofSeconds(5))
 
         _ <- ZIO.log("Checking if the data is in the target table")
         beforeEvolution <- Common.getData(
@@ -130,11 +131,12 @@ object SchemaMigrationTests extends ZIOSpecDefault:
         sourceConnection <- ZIO.succeed(Fixtures.getConnection)
         _ <- Common.addColumns(sourceConnection, sourceTableName, "NewName VARCHAR(100)")
 
-        lifetimeService = ZLayer.succeed(TimeLimitLifetimeService(Duration.ofSeconds(15)))
+        lifetimeService = ZLayer.succeed(TimeLimitLifetimeService(Duration.ofSeconds(35)))
         streamRunner <- Common.buildTestApp(lifetimeService, streamingStreamContextLayer).fork
+        _ <- ZIO.sleep(Duration.ofSeconds(10))
 
         _ <- Common.insertUpdatedData(sourceConnection, sourceTableName, streamingData)
-        _ <- ZIO.sleep(Duration.ofSeconds(15))
+        _ <- ZIO.sleep(Duration.ofSeconds(5))
         _ <- ZIO.log("Checking if the data is in the target table")
         beforeEvolution <- Common.getData(streamingStreamContext.targetTableFullName,
           "Id, Name, NewName",

--- a/src/test/scala/tests/integration/SchemaMigrationTests.scala
+++ b/src/test/scala/tests/integration/SchemaMigrationTests.scala
@@ -132,8 +132,8 @@ object SchemaMigrationTests extends ZIOSpecDefault:
 
         streamRunner <- Common.buildTestApp(TimeLimitLifetimeService.layer, streamingStreamContextLayer).fork
         _ <- Common.insertUpdatedData(sourceConnection, sourceTableName, streamingData)
-        _ <- ZIO.sleep(Duration.ofSeconds(5))
 
+        _ <- ZIO.sleep(Duration.ofSeconds(15))
         beforeEvolution <- Common.getData(streamingStreamContext.targetTableFullName,
           "Id, Name, NewName",
           (rs: ResultSet) => (rs.getInt(1), rs.getString(2), rs.getString(3))
@@ -143,7 +143,7 @@ object SchemaMigrationTests extends ZIOSpecDefault:
         _ <- Common.removeColumns(sourceConnection, sourceTableName, "NewName")
         _ <- ZIO.sleep(Duration.ofSeconds(1))
         _ <- Common.insertData(sourceConnection, sourceTableName, afterEvolution)
-        _ <- ZIO.sleep(Duration.ofSeconds(5))
+        _ <- ZIO.sleep(Duration.ofSeconds(15))
 
         afterEvolution <- Common.getData(
           streamingStreamContext.targetTableFullName,

--- a/src/test/scala/tests/integration/SchemaMigrationTests.scala
+++ b/src/test/scala/tests/integration/SchemaMigrationTests.scala
@@ -1,0 +1,152 @@
+package com.sneaksanddata.arcane.sql_server_change_tracking
+package tests.integration
+
+import models.app.{SqlServerChangeTrackingStreamContext, StreamSpec, given_Conversion_SqlServerChangeTrackingStreamContext_ConnectionOptions}
+import tests.common.{Common, TimeLimitLifetimeService}
+
+import com.sneaksanddata.arcane.framework.services.mssql.ConnectionOptions
+import zio.test.TestAspect.timeout
+import zio.test.{Spec, TestAspect, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.{Scope, ZIO, ZLayer}
+
+import java.sql.ResultSet
+import java.time.Duration
+
+object SchemaMigrationTests extends ZIOSpecDefault:
+  val sourceTableName = "SchemaEvolutionTests"
+  val targetTableName = "iceberg.test.schema_evolution"
+
+  private val streamContextStr =
+    s"""
+       |
+       | {
+       |  "groupingIntervalSeconds": 1,
+       |  "maxRowsPerFile": 1,
+       |  "lookBackInterval": 21000,
+       |  "tableProperties": {
+       |    "partitionExpressions": [],
+       |    "format": "PARQUET",
+       |    "sortedBy": [],
+       |    "parquetBloomFilterColumns": []
+       |  },
+       |  "rowsPerGroup": 10000,
+       |  "sinkSettings": {
+       |    "optimizeSettings": {
+       |      "batchThreshold": 60,
+       |      "fileSizeThreshold": "512MB"
+       |    },
+       |    "orphanFilesExpirationSettings": {
+       |      "batchThreshold": 60,
+       |      "retentionThreshold": "6h"
+       |    },
+       |    "snapshotExpirationSettings": {
+       |      "batchThreshold": 60,
+       |      "retentionThreshold": "6h"
+       |    },
+       |    "targetTableName": "$targetTableName"
+       |  },
+       |  "sourceSettings": {
+       |    "changeCaptureIntervalSeconds": 1,
+       |    "commandTimeout": 3600,
+       |    "database": "IntegrationTests",
+       |    "schema": "dbo",
+       |    "table": "$sourceTableName"
+       |   },
+       |  "stagingDataSettings": {
+       |    "catalog": {
+       |      "catalogName": "iceberg",
+       |      "catalogUri": "http://localhost:20001/catalog",
+       |      "namespace": "test",
+       |      "schemaName": "test",
+       |      "warehouse": "demo"
+       |    },
+       |    "tableNamePrefix": "staging_integration_tests"
+       |  },
+       |  "fieldSelectionRule": {
+       |    "ruleType": "all",
+       |    "fields": []
+       |  }
+       |}
+       |
+       |""".stripMargin
+
+  private val parsedSpec = StreamSpec.fromString(streamContextStr)
+
+  private val streamingStreamContext = new SqlServerChangeTrackingStreamContext(parsedSpec):
+    override val IsBackfilling: Boolean = false
+
+  private val streamingStreamContextLayer = ZLayer.succeed[SqlServerChangeTrackingStreamContext](streamingStreamContext)
+    ++ ZLayer.succeed[ConnectionOptions](streamingStreamContext)
+
+  private def before = TestAspect.before(Fixtures.withFreshTablesZIO(sourceTableName, targetTableName))
+
+
+  def spec: Spec[TestEnvironment & Scope, Throwable] = suite("StreamRunner") (
+
+    test("handle schema migration (column insertions)") {
+      val streamingData = List.range(1, 4).map(i => (i, s"Test$i"))
+      val afterEvolution = List.range(4, 7).map(i => (i, s"Test$i", s"Updated $i"))
+
+      val afterEvolutionExpected = List.range(1, 4).map(i => (i, s"Test$i", null))
+        ++ List.range(4, 7).map(i => (i, s"Test$i", s"Updated $i"))
+
+      for {
+        sourceConnection <- ZIO.succeed(Fixtures.getConnection)
+
+        streamRunner <- Common.buildTestApp(TimeLimitLifetimeService.layer, streamingStreamContextLayer).fork
+        _ <- Common.insertData(sourceConnection, sourceTableName, streamingData)
+        _ <- ZIO.sleep(Duration.ofSeconds(5))
+
+        beforeEvolution <- Common.getData(
+          streamingStreamContext.targetTableFullName,
+          "Id, Name",
+          (rs: ResultSet) => (rs.getInt(1), rs.getString(2))
+        )
+
+        _ <- ZIO.sleep(Duration.ofSeconds(5))
+        _ <- Common.addColumns(sourceConnection, sourceTableName, "NewName VARCHAR(100)")
+        _ <- Common.insertUpdatedData(sourceConnection, sourceTableName, afterEvolution)
+
+        _ <- streamRunner.await.timeout(Duration.ofSeconds(15))
+
+        afterStream <- Common.getData(streamingStreamContext.targetTableFullName,
+          "Id, Name, NewName",
+          (rs: ResultSet) => (rs.getInt(1), rs.getString(2), rs.getString(3))
+        )
+      } yield assertTrue(beforeEvolution.sorted == streamingData) && assertTrue(afterStream.sorted == afterEvolutionExpected)
+    },
+
+    test("handle schema migration (column deletions)") {
+      val streamingData = List.range(1, 4).map(i => (i, s"Test$i", s"Updated $i"))
+      val afterEvolution = List.range(4, 7).map(i => (i, s"Test$i"))
+
+      val afterEvolutionExpected = List.range(1, 4).map(i => (i, s"Test$i", s"Updated $i"))
+        ++ List.range(4, 7).map(i => (i, s"Test$i", null))
+
+      for {
+        sourceConnection <- ZIO.succeed(Fixtures.getConnection)
+        _ <- Common.addColumns(sourceConnection, sourceTableName, "NewName VARCHAR(100)")
+
+        streamRunner <- Common.buildTestApp(TimeLimitLifetimeService.layer, streamingStreamContextLayer).fork
+        _ <- Common.insertUpdatedData(sourceConnection, sourceTableName, streamingData)
+        _ <- ZIO.sleep(Duration.ofSeconds(5))
+
+        beforeEvolution <- Common.getData(streamingStreamContext.targetTableFullName,
+          "Id, Name, NewName",
+          (rs: ResultSet) => (rs.getInt(1), rs.getString(2), rs.getString(3))
+        )
+
+        _ <- Common.removeColumns(sourceConnection, sourceTableName, "NewName")
+        _ <- Common.insertData(sourceConnection, sourceTableName, afterEvolution)
+        _ <- ZIO.sleep(Duration.ofSeconds(5))
+
+        afterEvolution <- Common.getData(
+          streamingStreamContext.targetTableFullName,
+          "Id, Name, NewName",
+          (rs: ResultSet) => (rs.getInt(1), rs.getString(2), rs.getString(3))
+        )
+        _ <- streamRunner.await.timeout(Duration.ofSeconds(15))
+
+      } yield assertTrue(beforeEvolution.sorted == streamingData) && assertTrue(afterEvolution.sorted == afterEvolutionExpected)
+    }
+  ) @@ before @@ timeout(zio.Duration.fromSeconds(600)) @@ TestAspect.withLiveClock @@ TestAspect.sequential

--- a/src/test/scala/tests/integration/SchemaMigrationTests.scala
+++ b/src/test/scala/tests/integration/SchemaMigrationTests.scala
@@ -139,7 +139,9 @@ object SchemaMigrationTests extends ZIOSpecDefault:
           (rs: ResultSet) => (rs.getInt(1), rs.getString(2), rs.getString(3))
         )
 
+        _ <- ZIO.sleep(Duration.ofSeconds(5))
         _ <- Common.removeColumns(sourceConnection, sourceTableName, "NewName")
+        _ <- ZIO.sleep(Duration.ofSeconds(1))
         _ <- Common.insertData(sourceConnection, sourceTableName, afterEvolution)
         _ <- ZIO.sleep(Duration.ofSeconds(5))
 
@@ -148,7 +150,7 @@ object SchemaMigrationTests extends ZIOSpecDefault:
           "Id, Name, NewName",
           (rs: ResultSet) => (rs.getInt(1), rs.getString(2), rs.getString(3))
         )
-        _ <- streamRunner.await.timeout(Duration.ofSeconds(15))
+        _ <- streamRunner.await.timeout(Duration.ofSeconds(40))
 
       } yield assertTrue(beforeEvolution.sorted == streamingData) && assertTrue(afterEvolution.sorted == afterEvolutionExpected)
     }

--- a/src/test/scala/tests/integration/SchemaMigrationTests.scala
+++ b/src/test/scala/tests/integration/SchemaMigrationTests.scala
@@ -109,7 +109,7 @@ object SchemaMigrationTests extends ZIOSpecDefault:
         _ <- ZIO.sleep(Duration.ofSeconds(1))
         _ <- Common.insertUpdatedData(sourceConnection, sourceTableName, afterEvolution)
 
-        _ <- streamRunner.await.timeout(Duration.ofSeconds(20))
+        _ <- streamRunner.await.timeout(Duration.ofSeconds(40))
 
         afterStream <- Common.getData(streamingStreamContext.targetTableFullName,
           "Id, Name, NewName",

--- a/src/test/scala/tests/integration/StreamRunner.scala
+++ b/src/test/scala/tests/integration/StreamRunner.scala
@@ -103,15 +103,15 @@ class StreamRunner  extends AsyncFlatSpec with Matchers:
     val test = for
       // Testing the stream runner in the streaming mode
       streamRunner <- Common.buildTestApp(TimeLimitLifetimeService.layer, streamingStreamContextLayer).fork
-      _ <- Common.insertData(sourceConnection, streamingData)
+      _ <- Common.insertData(sourceConnection, "dbo.TestTable", streamingData)
       _ <- streamRunner.await.timeout(Duration.ofSeconds(15))
-      afterStream <- Common.getData(streamingStreamContext.targetTableFullName, resultSetDecoder)
+      afterStream <- Common.getData(streamingStreamContext.targetTableFullName, "Id, Name", resultSetDecoder)
 
       // Testing the stream runner in the backfill mode
       streamRunner <- Common.buildTestApp(TimeLimitLifetimeService.layer, backfillStreamContextLayer).fork
-      _ <- Common.insertData(sourceConnection, backfillData)
+      _ <- Common.insertData(sourceConnection, "dbo.TestTable", backfillData)
       _ <- streamRunner.await.timeout(Duration.ofSeconds(15))
-      afterBackfill <- Common.getData(streamingStreamContext.targetTableFullName, resultSetDecoder)
+      afterBackfill <- Common.getData(streamingStreamContext.targetTableFullName, "Id, Name", resultSetDecoder)
 
       // Testing the update and delete operations
       streamRunner <- Common.buildTestApp(TimeLimitLifetimeService.layer, streamingStreamContextLayer).fork
@@ -119,7 +119,7 @@ class StreamRunner  extends AsyncFlatSpec with Matchers:
       _ <- Common.deleteData(sourceConnection, deletedData)
       _ <- zlog("data deleted")
       _ <- streamRunner.await.timeout(Duration.ofSeconds(15))
-      afterUpdateDelete <- Common.getData(streamingStreamContext.targetTableFullName, resultSetDecoder)
+      afterUpdateDelete <- Common.getData(streamingStreamContext.targetTableFullName, "Id, Name", resultSetDecoder)
     yield (afterStream, afterBackfill, afterUpdateDelete)
 
     Unsafe.unsafe(implicit unsafe => runtime.unsafe.runToFuture(test.timeout(testTimeout))).map {


### PR DESCRIPTION
Resolves #158

## Scope

These tests validate the stream runner behavior during the schema evolution


## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.