### PR TITLE
Update merge service retry defaults

### DIFF
--- a/.helm/templates/crd-microsoft-sql-server-stream-beta.yaml
+++ b/.helm/templates/crd-microsoft-sql-server-stream-beta.yaml
@@ -182,7 +182,7 @@ spec:
                           default: 3
                         queryRetryScaleFactor:
                           type: number
-                          default: 0.1
+                          default: 3.0
                         queryRetryOnMessageContents:
                           type: array
                           items:
@@ -190,7 +190,7 @@ spec:
                           default: [ ]
                         queryRetryBaseDuration:
                           type: string
-                          default: 500 millisecond
+                          default: 1 second
                         queryRetryMode:
                           type: object
                           properties:

--- a/.helm/templates/crd-microsoft-sql-server-stream.yaml
+++ b/.helm/templates/crd-microsoft-sql-server-stream.yaml
@@ -154,7 +154,7 @@ spec:
                           default: 3
                         queryRetryScaleFactor:
                           type: number
-                          default: 0.1
+                          default: 3.0
                         queryRetryOnMessageContents:
                           type: array
                           items:
@@ -162,7 +162,7 @@ spec:
                           default: [ ]
                         queryRetryBaseDuration:
                           type: string
-                          default: 500 millisecond
+                          default: 1 second
                         queryRetryMode:
                           type: object
                           properties:


### PR DESCRIPTION
Updating merge service retry defaults.

With this change we'll have `queryRetryMaxAttempts=3`, `queryRetryScaleFactor=3.0` and `queryRetryBaseDuration=1 second`, which gives retry spread: 1s, 3s, 9s (+/- jitter)